### PR TITLE
Pick up newer psycopg2 with support for psql 10+

### DIFF
--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -1,3 +1,3 @@
 -r base.txt
 
-psycopg2==2.6.1
+psycopg2==2.7.3.2


### PR DESCRIPTION
Travis CI currently failing: `Error: could not determine PostgreSQL version from '10.1'`