### PR TITLE
Update gpg setup section in readme

### DIFF
--- a/scripts/backups/README.md
+++ b/scripts/backups/README.md
@@ -58,7 +58,7 @@ key-pair for the backups) and then export the GPG public key:
 # Create a GPG key. If you're unsure of which options to pick at the prompts,
 # use '(1)' for 'RSA and RSA', 4096 bits, and '(0)' for 'No expiration'. An
 # example user ID is 'Checkniner (backups) <checkniner@example.com>'
-$ gpg --gen-key
+$ gpg --full-gen-key
 # Now export the public key
 $ gpg --export [8-digit key ID created above] --output checkniner_public.gpg
 ```


### PR DESCRIPTION
Ubuntu 18.04 appears to use gpg v2 by default. This change appears to affect the behavior of the `--gen-key` switch. It no longer allows the selection of a key type, size, or expiration date. Using `--full-gen-key` resolves this.