### PR TITLE
Add path to crontab

### DIFF
--- a/scripts/prep_production
+++ b/scripts/prep_production
@@ -61,6 +61,7 @@ if sudo crontab -l > /dev/null; then
 else
     echo -n '' | sudo tee ~/crontab
 fi
+echo "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
 echo "0 0 6 * * certbot renew && systemctl reload nginx" \
     | sudo tee -a ~/crontab
 echo "15 15 * * * apt-get update && DEBIAN_FRONTEND=noninteractive apt-get dist-upgrade -yq && apt-get autoremove -y" \


### PR DESCRIPTION
On some Ubuntu installations, for reasons not fully understood, use of `apt-get dist-upgrade` in the root crontab fails unles a PATH env variable is declared. This change resolves that.